### PR TITLE
no_std support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ categories = ["compression", "multimedia::audio", "multimedia::encoding", "algor
 readme = "README.md"
 
 [dependencies]
+micromath = "2.1.0"
 
 [dev-dependencies]
 zerocopy = "0.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,6 @@ micromath = "2.1.0"
 
 [dev-dependencies]
 zerocopy = "0.3.0"
+
+[features]
+micromath = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,10 @@ categories = ["compression", "multimedia::audio", "multimedia::encoding", "algor
 readme = "README.md"
 
 [dependencies]
-micromath = "2.1.0"
+micromath = {version = "2.1.0", optional = true}
 
 [dev-dependencies]
 zerocopy = "0.3.0"
 
 [features]
-micromath = []
+micromath = ["dep:micromath"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,10 +59,11 @@
 #![allow(non_camel_case_types)]
 #![allow(non_upper_case_globals)]
 #![warn(trivial_numeric_casts)]
-#![no_std]
+#![cfg_attr(micromath, no_std)]
 
 extern crate alloc;
 use alloc::{vec, vec::Vec};
+#[cfg(micromath)]
 #[allow(unused_imports)]
 use micromath::F32Ext;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,9 +59,19 @@
 #![allow(non_camel_case_types)]
 #![allow(non_upper_case_globals)]
 #![warn(trivial_numeric_casts)]
+#![no_std]
+
+extern crate alloc;
+use alloc::{vec, vec::Vec};
+#[allow(unused_imports)]
+use micromath::F32Ext;
 
 #[cfg(test)]
 mod tests {
+    extern crate std;
+    use super::*;
+    use std::*;
+
     #[test]
     fn encode_test() {
         let mut c2 = crate::Codec2::new(crate::Codec2Mode::MODE_3200);
@@ -118,7 +128,7 @@ const WO_BITS: i32 = 7;
 const WO_E_BITS: u32 = 8;
 const LSPD_SCALAR_INDEXES: usize = 10;
 const LSP_SCALAR_INDEXES: usize = 10;
-use std::f64::consts::PI;
+use core::f32::consts::PI;
 
 const N_S: f32 = 0.01; //  internal proc frame length in secs
 const TW_S: f32 = 0.005; //  trapezoidal synth window overlap
@@ -134,6 +144,8 @@ const P_MIN_S: f32 = 0.0025; //  minimum pitch period in s
 const P_MAX_S: f32 = 0.0200; //  maximum pitch period in s
 mod inner {
     use crate::*;
+    use core::fmt;
+
     #[derive(Clone, Debug)]
     pub struct C2const {
         pub Fs: i32,       //  sample rate of this instance
@@ -225,15 +237,15 @@ mod inner {
         pub fn new() -> Self {
             Self { r: 0.0, i: 0.0 }
         }
-        pub fn kf_cexp(phase: f64) -> Self {
+        pub fn kf_cexp(phase: f32) -> Self {
             Self {
-                r: phase.cos() as f32,
-                i: phase.sin() as f32,
+                r: phase.cos(),
+                i: phase.sin(),
             }
         }
     }
-    impl std::fmt::Debug for kiss_fft_cpx {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    impl fmt::Debug for kiss_fft_cpx {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             f.write_fmt(format_args!("{},{}", self.r, self.i))
         }
     }
@@ -250,7 +262,7 @@ mod inner {
             let mut twiddles = Vec::with_capacity(nfft);
             let mut factors = [0; 2 * MAXFACTORS];
             for i in 0..nfft {
-                let mut phase = -2.0 * PI * (i as f64) / (nfft as f64);
+                let mut phase = -2.0 * PI * (i as f32) / (nfft as f32);
                 if inverse_fft != 0 {
                     phase *= -1.0;
                 }
@@ -258,7 +270,7 @@ mod inner {
             }
             let mut n = nfft;
             let mut p = 4;
-            let floor_sqrt = (n as f64).sqrt().floor() as usize;
+            let floor_sqrt = (n as f32).sqrt().floor() as usize;
             let mut idx = 0;
             // factor out powers of 4, powers of 2, then any remaining primes
             loop {
@@ -305,7 +317,7 @@ mod inner {
             };
             for i in 0..nfft / 2 {
                 let mut phase =
-                    -3.14159265358979323846264338327 * ((i as f64 + 1.0) / nfft as f64 + 0.5);
+                    -3.14159265358979323846264338327 * ((i as f32 + 1.0) / nfft as f32 + 0.5);
                 if inverse_fft != 0 {
                     phase *= -1.0;
                 }
@@ -339,8 +351,7 @@ mod inner {
             };
             let mut w = [0.0; PMAX_M / DEC];
             for i in 0..m / DEC {
-                w[i] =
-                    0.5 - 0.5 * (2.0 * PI as f32 * i as f32 / (m as f32 / DEC as f32 - 1.0)).cos();
+                w[i] = 0.5 - 0.5 * (2.0 * PI * i as f32 / (m as f32 / DEC as f32 - 1.0)).cos();
             }
             Self {
                 Fs: c2const.Fs, //  sample rate in Hz
@@ -367,11 +378,11 @@ mod inner {
         pub fn new(p_max: f32) -> Self {
             let wo = TWO_PI / p_max;
             Self {
-                Wo: wo,                               //  fundamental frequency estimate in radians
-                L: (PI / wo as f64).floor() as usize, //  number of harmonics
-                A: [0.0; MAX_AMP + 1],                //  amplitiude of each harmonic
-                phi: [0.0; MAX_AMP + 1],              //  phase of each harmonic
-                voiced: 0,                            //  non-zero if this frame is voiced
+                Wo: wo,                        //  fundamental frequency estimate in radians
+                L: (PI / wo).floor() as usize, //  number of harmonics
+                A: [0.0; MAX_AMP + 1],         //  amplitiude of each harmonic
+                phi: [0.0; MAX_AMP + 1],       //  phase of each harmonic
+                voiced: 0,                     //  non-zero if this frame is voiced
             }
         }
     }
@@ -784,7 +795,7 @@ impl Codec2 {
             },
         };
         for i in 0..LPC_ORD {
-            c2.internal.prev_lsps_dec[i] = (i as f64 * PI / (LPC_ORD as f64 + 1.0)) as f32;
+            c2.internal.prev_lsps_dec[i] = i as f32 * PI / (LPC_ORD as f32 + 1.0);
         }
         make_analysis_window(
             &c2.internal.c2const,
@@ -938,7 +949,7 @@ impl Codec2 {
 
         let Wo_index = unpack(bits, &mut nbit, WO_BITS as u32);
         model[1].Wo = decode_Wo(&self.internal.c2const, Wo_index, WO_BITS);
-        model[1].L = (PI / model[1].Wo as f64) as usize;
+        model[1].L = (PI / model[1].Wo) as usize;
 
         let mut e = [0.0; 2];
         let e_index = unpack(bits, &mut nbit, E_BITS as u32);
@@ -1303,7 +1314,7 @@ impl Codec2 {
         model[1].voiced = unpack(bits, &mut nbit, 1);
         let Wo_index = unpack(bits, &mut nbit, WO_BITS as u32);
         model[1].Wo = decode_Wo(&self.internal.c2const, Wo_index, WO_BITS);
-        model[1].L = (PI as f32 / model[1].Wo) as usize;
+        model[1].L = (PI / model[1].Wo) as usize;
 
         let mut e_index = unpack(bits, &mut nbit, E_BITS as u32);
         e[1] = decode_energy(e_index, E_BITS);
@@ -1313,7 +1324,7 @@ impl Codec2 {
         model[3].voiced = unpack(bits, &mut nbit, 1);
         let Wo_index = unpack(bits, &mut nbit, WO_BITS as u32);
         model[3].Wo = decode_Wo(&self.internal.c2const, Wo_index, WO_BITS);
-        model[3].L = (PI as f32 / model[3].Wo) as usize;
+        model[3].L = (PI / model[3].Wo) as usize;
 
         e_index = unpack(bits, &mut nbit, E_BITS as u32);
         e[3] = decode_energy(e_index, E_BITS);
@@ -1719,7 +1730,7 @@ impl Codec2 {
         let Wo_index =
             unpack_natural_or_gray(bits, &mut nbit, WO_BITS as u32, self.internal.gray as u32);
         model[3].Wo = decode_Wo(&self.internal.c2const, Wo_index, WO_BITS);
-        model[3].L = (PI as f32 / model[3].Wo) as usize;
+        model[3].L = (PI / model[3].Wo) as usize;
 
         let e_index =
             unpack_natural_or_gray(bits, &mut nbit, E_BITS as u32, self.internal.gray as u32);
@@ -2090,7 +2101,7 @@ impl Codec2 {
             &mut self.internal.prev_f0_enc,
         );
         model.Wo = TWO_PI / pitch;
-        model.L = (PI / model.Wo as f64) as usize;
+        model.L = (PI / model.Wo) as usize;
 
         //  estimate model parameters
         two_stage_pitch_refinement(&self.internal.c2const, model, &Sw);
@@ -2376,10 +2387,10 @@ fn two_stage_pitch_refinement(c2const: &C2const, model: &mut MODEL, Sw: &[COMP])
         model.Wo = TWO_PI / (c2const.p_min as f32);
     }
 
-    model.L = (PI / model.Wo as f64).floor() as usize;
+    model.L = (PI / model.Wo).floor() as usize;
 
     //  trap occasional round off issues with floorf()
-    if model.Wo * model.L as f32 >= 0.95 * PI as f32 {
+    if model.Wo * model.L as f32 >= 0.95 * PI {
         model.L -= 1;
     }
     //  assert(model.Wo*model.L < PI);
@@ -2404,7 +2415,7 @@ fn two_stage_pitch_refinement(c2const: &C2const, model: &mut MODEL, Sw: &[COMP])
 fn hs_pitch_refinement(model: &mut MODEL, Sw: &[COMP], pmin: f32, pmax: f32, pstep: f32) {
     //  Initialisation
 
-    model.L = (PI / model.Wo as f64) as usize; //  use initial pitch est. for L
+    model.L = (PI / model.Wo) as usize; //  use initial pitch est. for L
     let mut Wom = model.Wo; // Wo that maximises E
     let mut Em = 0.0; // mamimum energy
     let r = TWO_PI / FFT_ENC as f32; // number of rads/bin

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,11 +59,11 @@
 #![allow(non_camel_case_types)]
 #![allow(non_upper_case_globals)]
 #![warn(trivial_numeric_casts)]
-#![cfg_attr(micromath, no_std)]
+#![cfg_attr(feature = "micromath", no_std)]
 
 extern crate alloc;
 use alloc::{vec, vec::Vec};
-#[cfg(micromath)]
+#[cfg(feature = "micromath")]
 #[allow(unused_imports)]
 use micromath::F32Ext;
 

--- a/src/quantise.rs
+++ b/src/quantise.rs
@@ -1,5 +1,6 @@
 use crate::*;
 use core::sync::atomic;
+#[cfg(micromath)]
 #[allow(unused_imports)]
 use micromath::F32Ext;
 

--- a/src/quantise.rs
+++ b/src/quantise.rs
@@ -1,6 +1,6 @@
 use crate::*;
 use core::sync::atomic;
-#[cfg(micromath)]
+#[cfg(feature = "micromath")]
 #[allow(unused_imports)]
 use micromath::F32Ext;
 

--- a/src/quantise.rs
+++ b/src/quantise.rs
@@ -1,4 +1,8 @@
 use crate::*;
+use core::sync::atomic;
+#[allow(unused_imports)]
+use micromath::F32Ext;
+
 const LSP_DELTA1: f32 = 0.01;
 const E_MIN_DB: f32 = -10.0;
 const E_MAX_DB: f32 = 40.0;
@@ -291,7 +295,7 @@ pub fn encode_WoE(model: &MODEL, mut e: f32, xq: &mut [f32]) -> i32 {
     } /* occasional small negative energies due LPC round off I guess */
 
     let mut x = [0.0, 0.0];
-    x[0] = ((model.Wo / PI as f32) * 4000.0 / 50.0).log10() / 2.0_f32.log10();
+    x[0] = ((model.Wo / PI) * 4000.0 / 50.0).log10() / 2.0_f32.log10();
     x[1] = 10.0 * (1e-4 + e).log10();
 
     compute_weights2(&x, xq, &mut w);
@@ -355,7 +359,7 @@ fn compute_weights(x: &[f32], w: &mut [f32], ndim: usize) {
     for i in 1..ndim - 1 {
         w[i] = f32::min(x[i] - x[i - 1], x[i + 1] - x[i]);
     }
-    w[ndim - 1] = f32::min(x[ndim - 1] - x[ndim - 2], PI as f32 - x[ndim - 1]);
+    w[ndim - 1] = f32::min(x[ndim - 1] - x[ndim - 2], PI - x[ndim - 1]);
 
     for i in 0..ndim {
         w[i] = 1. / (0.01 + w[i]);
@@ -420,7 +424,7 @@ pub fn encode_lsps_scalar(indexes: &mut [i32], lsp: &[f32], order: usize) {
     frequencies */
 
     for i in 0..order {
-        lsp_hz[i] = (4000.0 / PI as f32) * lsp[i];
+        lsp_hz[i] = (4000.0 / PI) * lsp[i];
     }
     /* scalar quantisers */
 
@@ -481,7 +485,7 @@ pub fn speech_to_uq_lsps(
 
     if e == 0.0 {
         for i in 0..order {
-            lsp[i] = (PI as f32 / order as f32) * (i as f32);
+            lsp[i] = (PI / order as f32) * (i as f32);
         }
         return 0.0;
     }
@@ -506,7 +510,7 @@ pub fn speech_to_uq_lsps(
     if roots != order as i32 {
         //  if root finding fails use some benign LSP values instead
         for i in 0..order {
-            lsp[i] = (PI as f32 / order as f32) * (i as f32);
+            lsp[i] = (PI / order as f32) * (i as f32);
         }
     }
 
@@ -574,7 +578,7 @@ pub fn encode_lspds_scalar(indexes: &mut [i32], lsp: &[f32], order: usize) {
     //  convert from radians to Hz so we can use human readable frequencies
 
     for i in 0..order {
-        lsp_hz[i] = (4000.0 / PI as f32) * lsp[i];
+        lsp_hz[i] = (4000.0 / PI) * lsp[i];
     }
     wt[0] = 1.0;
     for i in 0..order {
@@ -980,12 +984,12 @@ pub fn phase_synth_zero_order(
 const CODEC2_RAND_MAX: f32 = 32767.0;
 
 //  todo: this should probably be in some states rather than a static
-static next_rand: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(1);
+static next_rand: atomic::AtomicUsize = atomic::AtomicUsize::new(1);
 fn codec2_rand() -> f32 {
     // next = next * 1103515245 + 12345 but allow overflow and allow thready accesses.
-    let mut nextr = next_rand.load(std::sync::atomic::Ordering::Relaxed);
+    let mut nextr = next_rand.load(atomic::Ordering::Relaxed);
     nextr = nextr.overflowing_mul(1103515245).0.overflowing_add(12345).0;
-    next_rand.store(nextr, std::sync::atomic::Ordering::Relaxed);
+    next_rand.store(nextr, atomic::Ordering::Relaxed);
     ((nextr / 65536) % 32768) as f32
 }
 
@@ -1175,7 +1179,7 @@ pub fn interp_Wo2(
     } else {
         interp.Wo = Wo_min;
     }
-    interp.L = (PI / interp.Wo as f64) as usize;
+    interp.L = (PI / interp.Wo) as usize;
     interp
 }
 
@@ -1211,7 +1215,7 @@ pub fn interpolate_lsp_ver2(
 
 \*---------------------------------------------------------------------------*/
 pub fn apply_lpc_correction(model: &mut MODEL) {
-    if model.Wo < (PI as f32 * 150.0 / 4000.0) {
+    if model.Wo < (PI * 150.0 / 4000.0) {
         model.A[1] *= 0.032;
     }
 }
@@ -1229,7 +1233,7 @@ pub fn decode_lspds_scalar(lsp_: &mut [f32], indexes: &[usize], order: usize) {
         } else {
             lsp__hz[0] = dlsp_[0];
         }
-        lsp_[i] = (PI as f32 / 4000.0) * lsp__hz[i];
+        lsp_[i] = (PI / 4000.0) * lsp__hz[i];
     }
 }
 
@@ -1467,8 +1471,8 @@ pub fn postfilter(model: &mut MODEL, bg_est: &mut f32) {
 
 pub fn bw_expand_lsps(lsp: &mut [f32], order: usize, min_sep_low: f32, min_sep_high: f32) {
     for i in 1..4 {
-        if (lsp[i] - lsp[i - 1]) < min_sep_low * (PI as f32 / 4000.0) {
-            lsp[i] = lsp[i - 1] + min_sep_low * (PI as f32 / 4000.0);
+        if (lsp[i] - lsp[i - 1]) < min_sep_low * (PI / 4000.0) {
+            lsp[i] = lsp[i - 1] + min_sep_low * (PI / 4000.0);
         }
     }
 
@@ -1478,8 +1482,8 @@ pub fn bw_expand_lsps(lsp: &mut [f32], order: usize, min_sep_low: f32, min_sep_h
     */
 
     for i in 4..order {
-        if lsp[i] - lsp[i - 1] < min_sep_high * (PI as f32 / 4000.0) {
-            lsp[i] = lsp[i - 1] + min_sep_high * (PI as f32 / 4000.0);
+        if lsp[i] - lsp[i - 1] < min_sep_high * (PI / 4000.0) {
+            lsp[i] = lsp[i - 1] + min_sep_high * (PI / 4000.0);
         }
     }
 }
@@ -1524,7 +1528,7 @@ pub fn decode_lsps_scalar(lsp: &mut [f32], indexes: &[usize], order: usize) {
     /* convert back to radians */
 
     for i in 0..order {
-        lsp[i] = (PI as f32 / 4000.0) * lsp_hz[i];
+        lsp[i] = (PI / 4000.0) * lsp_hz[i];
     }
 }
 
@@ -1550,7 +1554,7 @@ pub fn encode_lsps_vq(indexes: &mut [usize], x: &mut [f32], xq: &mut [f32], orde
     for i in 1..order - 1 {
         w[i] = f32::min(x[i] - x[i - 1], x[i + 1] - x[i]);
     }
-    w[order - 1] = f32::min(x[order - 1] - x[order - 2], PI as f32 - x[order - 1]);
+    w[order - 1] = f32::min(x[order - 1] - x[order - 2], PI - x[order - 1]);
 
     compute_weights(x, &mut w, order);
 
@@ -1622,7 +1626,7 @@ pub fn decode_WoE(c2const: &C2const, model: &mut MODEL, e: &mut f32, xq: &mut [f
     }
 
     //printf("dec: %f %f\n", xq[0], xq[1]);
-    model.Wo = 2.0_f32.powf(xq[0]) * (PI as f32 * 50.0) / 4000.0;
+    model.Wo = 2.0_f32.powf(xq[0]) * (PI * 50.0) / 4000.0;
 
     /* bit errors can make us go out of range leading to all sorts of
     probs like seg faults */
@@ -1634,7 +1638,7 @@ pub fn decode_WoE(c2const: &C2const, model: &mut MODEL, e: &mut f32, xq: &mut [f
         model.Wo = Wo_min
     };
 
-    model.L = (PI / model.Wo as f64) as usize; // if we quantise Wo re-compute L
+    model.L = (PI / model.Wo) as usize; // if we quantise Wo re-compute L
 
     *e = 10.0_f32.powf(xq[1] / 10.0);
 }


### PR DESCRIPTION
This is a draft to add no_std support. I simply added the `#[no_std]` directive and fixed compiler errors, swapped all floats to f32, and added micromath to provide float operations. The tests still pass, and the example encode/decode program works the same. I have not tested against the original codec2 implementation, though I would be quite surprised if it didn't work.